### PR TITLE
updated distrobox setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Afterwards, follow steps 1 & 2 to build the ISO...
 
 - Create The Container :
 ```
-distrobox create -i quay.io/toolbx-images/archlinux-toolbox -n "xerobuilder"
+distrobox create -i quay.io/toolbx-images/archlinux-toolbox -n "xerobuilder" --root  
 ```
 
 - Enter the Container :


### PR DESCRIPTION
I updated the distrobox setup instructions because if you do not initialize the container with root, it will fail to build due to permission denied errors